### PR TITLE
Implement core/persona.py module and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The `core.brain` module is a central component, housing the `SpacetimeManifold` 
 
 The `core.memory` module manages Sophia_Alpha2's knowledge graph, stored in `data/memory_store/knowledge_graph.json`. It handles storing new concepts based on novelty and ethical alignment, calculates concept novelty, and provides various functions for retrieving memories.
 
-Both `core.brain` and `core.memory` (and other future core modules) are extensively configurable via `config/config.py`.
+The `core.persona` module manages Sophia_Alpha2's identity, traits, operational mode, and evolving awareness state. Handles the persistence of this state to `persona_profile.json` (path typically defined in `config.PERSONA_PROFILE_PATH`).
+
+All core modules are designed to be extensively configurable via `config/config.py`.
 
 ## Directory Structure
 ```
@@ -34,7 +36,7 @@ Sophia_Alpha2_ResonantBuild/
 │   ├── gui.py         # (Stub) For Streamlit-based GUI
 │   ├── library.py     # (Stub) For knowledge library management
 │   ├── memory.py      # Manages the knowledge graph (storing, retrieving, novelty calculation)
-│   └── persona.py     # (Stub) For persona management
+│   └── persona.py     # Manages Sophia_Alpha2's identity, traits, mode, and awareness state
 ├── data/
 │   ├── ethics_store/
 │   │   └── .gitkeep
@@ -71,8 +73,8 @@ Sophia_Alpha2_ResonantBuild/
 ## Roadmap
 (Placeholder for Project Roadmap - To be populated later)
 *   Phase 1: Initial Scaffolding (Complete)
-*   Phase 2: Core module implementation (config.py complete, brain.py complete, memory.py complete)
-*   Phase 3: Implementation of ethics, persona, dialogue, and GUI modules.
+*   Phase 2: Core module implementation (config.py complete, brain.py complete, memory.py complete, persona.py updated)
+*   Phase 3: Implementation of ethics, dialogue, and GUI modules.
 *   Phase 4: ...
 
 ## Contributing

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -49,6 +49,9 @@ from .ethics import (
     track_trends
 )
 
+# --- Persona Exports ---
+from .persona import Persona
+
 __all__ = [
     # Brain components
     'SpacetimeManifold',
@@ -64,6 +67,8 @@ __all__ = [
     # Ethics components
     'score_ethics',
     'track_trends',
+    # Persona component
+    'Persona',
     # Other core components will be added here as they are developed
     # e.g., 'DialogueManager', 'PersonaManager', etc. 
     # Corrected placeholder from 'EthicsEngine' as it's now implemented.

--- a/core/persona.py
+++ b/core/persona.py
@@ -18,12 +18,12 @@ try:
     from .. import config
 except ImportError:
     # Fallback for standalone execution or testing
-    print("Persona.py: Could not import 'config' from parent package. Attempting relative import for standalone use.")
+    # print("Persona.py: Could not import 'config' from parent package. Attempting relative import for standalone use.")
     try:
-        import config
-        print("Persona.py: Successfully imported 'config' directly (likely for standalone testing).")
+        import config # type: ignore
+        # print("Persona.py: Successfully imported 'config' directly (likely for standalone testing).")
     except ImportError as e_config:
-        print(f"Persona.py: Failed to import 'config' for standalone use. Critical error: {e_config}")
+        # print(f"Persona.py: Failed to import 'config' for standalone use. Critical error: {e_config}")
         config = None # Placeholder, operations requiring config will fail
 
 class Persona:
@@ -39,59 +39,62 @@ class Persona:
         self.traits = ["CuriosityDriven", "EthicallyMinded", "ResonanceAware", "Developmental"]
         
         # Awareness metrics - initialized with sensible defaults
+        # primary_concept_coord is (scaled_x, scaled_y, scaled_z, raw_t_intensity_0_to_1)
         self.awareness = {
             "curiosity": 0.5,
             "context_stability": 0.5,
             "self_evolution_rate": 0.0,
             "coherence": 0.0,
             "active_llm_fallback": False,
-            "primary_concept_coord": None  # Expected to be a 4-tuple (x,y,z,t_intensity) or None
+            "primary_concept_coord": None
         }
 
         default_profile_filename = "persona_profile_default.json"
-        # Fallback profile path determination (module's directory/data/private if possible)
-        # This is a bit tricky as __file__ might not be reliable in all execution contexts (e.g. bundled)
+        # Fallback profile path determination
         try:
             module_dir = os.path.dirname(os.path.abspath(__file__))
-            fallback_data_dir = os.path.join(os.path.dirname(module_dir), 'data', 'private') # Assumes core/ is one level down from project root
-        except NameError: # __file__ not defined (e.g. interactive session, some bundled scenarios)
-            fallback_data_dir = os.path.join('.', 'data', 'private') # CWD/data/private as a last resort
+            # Assumes core/ is one level down from project root which contains data/private
+            fallback_data_dir = os.path.join(os.path.dirname(module_dir), 'data', 'private')
+        except NameError: # __file__ not defined
+            fallback_data_dir = os.path.join('.', 'data', 'private') # CWD/data/private
 
+        # Initialize profile_path with a default. It will be overridden by config if available.
         self.profile_path = os.path.join(fallback_data_dir, default_profile_filename)
-
 
         if config:
             self.name = getattr(config, 'PERSONA_NAME', default_name)
-            # Construct profile path using config attributes if available
-            # config.PERSONA_PROFILE_PATH should be the full, correct path from config.py
-            self.profile_path = getattr(config, 'PERSONA_PROFILE_PATH', self.profile_path) # Use pre-calculated fallback if not in config
+            # Use config.PERSONA_PROFILE_PATH for the profile path
+            self.profile_path = getattr(config, 'PERSONA_PROFILE_PATH', self.profile_path)
             
             if hasattr(config, 'ensure_path'):
                 try:
-                    config.ensure_path(self.profile_path)
+                    config.ensure_path(self.profile_path) # Ensures the directory for profile_path exists
                 except Exception as e_ensure:
                     print(f"Warning (Persona __init__): Error ensuring profile path '{self.profile_path}' via config.ensure_path: {e_ensure}", file=sys.stderr)
             else:
-                # Manual ensure_path if config.ensure_path is not available
+                # Manual ensure_path if config.ensure_path is not available (e.g. standalone testing without full config object)
                 try:
                     profile_dir = os.path.dirname(self.profile_path)
-                    if profile_dir and not os.path.exists(profile_dir):
+                    if profile_dir and not os.path.exists(profile_dir): # Only create if profile_dir is not empty (e.g. not current dir)
                         os.makedirs(profile_dir, exist_ok=True)
                 except Exception as e_manual_mkdir:
                      print(f"Warning (Persona __init__): Error manually ensuring profile directory for '{self.profile_path}': {e_manual_mkdir}", file=sys.stderr)
         else: 
-            print("Warning (Persona __init__): Config module not loaded. Persona will use default name and profile path.", file=sys.stderr)
-            # Manual ensure for default path if no config, using the already determined self.profile_path
+            # When config is None, we are likely in a standalone test.
+            # Ensure the profile directory exists for the default path.
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test): # Avoid print during automated tests
+                 print("Warning (Persona __init__): Config module not loaded. Persona will use default name and profile path. Attempting to ensure default path.", file=sys.stderr)
             try:
                 profile_dir = os.path.dirname(self.profile_path)
                 if profile_dir and not os.path.exists(profile_dir):
                     os.makedirs(profile_dir, exist_ok=True)
             except Exception as e_manual_mkdir_noconf:
-                print(f"Warning (Persona __init__): Error manually ensuring default profile directory for '{self.profile_path}': {e_manual_mkdir_noconf}", file=sys.stderr)
+                if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona __init__): Error manually ensuring default profile directory for '{self.profile_path}': {e_manual_mkdir_noconf}", file=sys.stderr)
 
         self.load_state() 
         
-        if config and getattr(config, 'VERBOSE_OUTPUT', False): # Check VERBOSE_OUTPUT from config if available
+        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
             print(f"Persona initialized: Name='{self.name}', Mode='{self.mode}', Profile='{self.profile_path}'", file=sys.stderr)
             print(f"Initial Awareness: {self.awareness}", file=sys.stderr)
 
@@ -99,52 +102,53 @@ class Persona:
         """
         Saves the current persona state to the profile JSON file.
         Includes name, mode, traits, and the full awareness dictionary.
+        The `primary_concept_coord` in awareness is stored as (scaled_x, scaled_y, scaled_z, raw_t_intensity_0_to_1).
         """
         state_to_save = {
             "name": self.name,
             "mode": self.mode,
             "traits": self.traits,
-            "awareness": self.awareness, # This will include primary_concept_coord
+            "awareness": self.awareness,
             "last_saved": datetime.datetime.utcnow().isoformat() + "Z"
         }
 
         try:
-            # Ensure directory exists one last time before writing (though __init__ tries)
             profile_dir = os.path.dirname(self.profile_path)
             if profile_dir and not os.path.exists(profile_dir):
                 os.makedirs(profile_dir, exist_ok=True)
-                if config and getattr(config, 'VERBOSE_OUTPUT', False):
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
                     print(f"Info (Persona save_state): Created missing profile directory: {profile_dir}", file=sys.stderr)
 
             with open(self.profile_path, 'w') as f:
                 json.dump(state_to_save, f, indent=2)
             
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
                 print(f"Info (Persona save_state): Persona state saved to {self.profile_path}", file=sys.stderr)
                 
         except IOError as e_io:
-            print(f"Error (Persona save_state): IOError saving persona state to {self.profile_path}: {e_io}", file=sys.stderr)
-            # Optionally, log this to a system log if available via config
-            # _log_system_event("persona_save_failure", {"path": self.profile_path, "error": str(e_io)}, level="error") # If logging is added
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Error (Persona save_state): IOError saving persona state to {self.profile_path}: {e_io}", file=sys.stderr)
         except Exception as e:
-            print(f"Error (Persona save_state): Unexpected error saving persona state to {self.profile_path}: {e}", file=sys.stderr)
-            # _log_system_event("persona_save_failure_unknown", {"path": self.profile_path, "error": str(e)}, level="critical")
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Error (Persona save_state): Unexpected error saving persona state to {self.profile_path}: {e}", file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+
 
     def _initialize_default_state_and_save(self):
         """
         Resets the persona attributes to their default values and saves the state.
         This is typically called if a profile file is not found or is invalid.
+        The `primary_concept_coord` defaults to None.
         """
-        if config and getattr(config, 'VERBOSE_OUTPUT', False):
+        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
             print(f"Info (Persona): Initializing default persona state for '{getattr(self, 'profile_path', 'N/A')}'.", file=sys.stderr)
 
-        default_name = "Sophia_Alpha2_Default_Reset" # Slightly different to indicate it was reset
-        # Use config values if config is loaded, otherwise hardcoded defaults from __init__
+        default_name = "Sophia_Alpha2_Default_Reset"
         self.name = getattr(config, 'PERSONA_NAME', default_name) if config else default_name
         self.mode = "reflective"
         self.traits = ["CuriosityDriven", "EthicallyMinded", "ResonanceAware", "Developmental"]
         
-        self.awareness = {
+        self.awareness = { # Default awareness state
             "curiosity": 0.5,
             "context_stability": 0.5,
             "self_evolution_rate": 0.0,
@@ -153,31 +157,27 @@ class Persona:
             "primary_concept_coord": None 
         }
         
-        # self.profile_path should already be set by __init__
-        # If it wasn't (e.g. config totally failed), save_state might have issues,
-        # but it has its own fallbacks/error handling.
-
-        if config and getattr(config, 'VERBOSE_OUTPUT', False):
+        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
             print(f"Info (Persona): Default state re-initialized. Name='{self.name}', Mode='{self.mode}'. Attempting save.", file=sys.stderr)
             
-        self.save_state() # Persist these defaults
+        self.save_state()
 
     def load_state(self):
         """
         Loads persona state from the profile JSON file.
-        Handles file not found, empty file, malformed JSON, and older formats
-        by gracefully applying available data and defaulting for missing fields.
-        If loading fails critically or no profile exists, initializes a default state.
+        Handles file not found, empty file, malformed JSON, and older formats.
+        `primary_concept_coord` is validated as a 4-tuple of numbers or None.
+        If loading fails critically, initializes a default state.
         """
         if not hasattr(self, 'profile_path') or not self.profile_path:
-            # This should not happen if __init__ runs correctly
-            print("Error (Persona load_state): profile_path not set. Cannot load.", file=sys.stderr)
-            self._initialize_default_state_and_save() # Initialize and save a default
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print("Error (Persona load_state): profile_path not set. Cannot load.", file=sys.stderr)
+            self._initialize_default_state_and_save()
             return
 
         if not os.path.exists(self.profile_path) or os.path.getsize(self.profile_path) == 0:
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                print(f"Info (Persona load_state): Profile file not found or empty: '{self.profile_path}'. Initializing default state.", file=sys.stderr)
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Info (Persona load_state): Profile file '{self.profile_path}' not found or empty. Initializing default state.", file=sys.stderr)
             self._initialize_default_state_and_save()
             return
 
@@ -186,144 +186,95 @@ class Persona:
                 loaded_state = json.load(f)
 
             if not isinstance(loaded_state, dict):
-                print(f"Warning (Persona load_state): Profile data in '{self.profile_path}' is not a dictionary. Initializing default state.", file=sys.stderr)
+                if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona load_state): Profile data in '{self.profile_path}' is not a dictionary. Initializing default state.", file=sys.stderr)
                 self._initialize_default_state_and_save()
                 return
 
-            # Load top-level attributes if present, otherwise keep __init__ defaults
             self.name = loaded_state.get("name", self.name)
             self.mode = loaded_state.get("mode", self.mode)
-            self.traits = loaded_state.get("traits", self.traits)
-            if not isinstance(self.traits, list) or not all(isinstance(t, str) for t in self.traits):
-                print(f"Warning (Persona load_state): Loaded 'traits' is not a list of strings. Using default traits.", file=sys.stderr)
+            
+            loaded_traits = loaded_state.get("traits", self.traits)
+            if isinstance(loaded_traits, list) and all(isinstance(t, str) for t in loaded_traits):
+                self.traits = loaded_traits
+            else:
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona load_state): Loaded 'traits' is not a list of strings. Using default traits.", file=sys.stderr)
                 self.traits = ["CuriosityDriven", "EthicallyMinded", "ResonanceAware", "Developmental"] # Default
 
-            # Load awareness metrics, applying type validation and defaults for missing keys
-            loaded_awareness = loaded_state.get("awareness", {})
-            if not isinstance(loaded_awareness, dict):
-                print(f"Warning (Persona load_state): Loaded 'awareness' data is not a dictionary. Using default awareness.", file=sys.stderr)
-                loaded_awareness = {} # Ensure it's a dict to prevent errors below
+            loaded_awareness_data = loaded_state.get("awareness", {})
+            if not isinstance(loaded_awareness_data, dict):
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona load_state): 'awareness' data in profile is not a dictionary. Using default awareness.", file=sys.stderr)
+                loaded_awareness_data = {} 
 
-            # Iterate over the keys defined in self.awareness by __init__ to ensure all expected keys are present
-            # and correctly typed, using loaded values where valid.
-            default_awareness_keys = {
+            default_awareness_template = { 
                 "curiosity": float, "context_stability": float, "self_evolution_rate": float,
-                "coherence": float, "active_llm_fallback": bool, "primary_concept_coord": 'tuple_4_float_or_none'
+                "coherence": float, "active_llm_fallback": bool
             }
 
-            for key, expected_type in default_awareness_keys.items():
-                if key in loaded_awareness:
-                    loaded_value = loaded_awareness[key]
-                    if expected_type == float:
-                        try:
-                            self.awareness[key] = float(loaded_value)
-                        except (ValueError, TypeError):
-                            print(f"Warning (Persona load_state): Invalid type for awareness key '{key}'. Expected float, got {type(loaded_value)}. Using default.", file=sys.stderr)
-                            # Default already set in self.awareness by __init__ if key was bad
-                    elif expected_type == bool:
-                        self.awareness[key] = bool(loaded_value) # Handles "true", "false", 0, 1 etc.
-                    elif key == "primary_concept_coord": # Special handling for 'tuple_4_float_or_none'
-                        if isinstance(loaded_value, (list, tuple)) and len(loaded_value) == 4:
-                            try:
-                                self.awareness[key] = tuple(float(v) for v in loaded_value)
-                            except (ValueError, TypeError):
-                                print(f"Warning (Persona load_state): Invalid numeric types in 'primary_concept_coord' list/tuple. Using None.", file=sys.stderr)
-                                self.awareness[key] = None
-                        elif loaded_value is None:
-                            self.awareness[key] = None
-                        else:
-                            print(f"Warning (Persona load_state): Invalid format for 'primary_concept_coord'. Expected list/tuple of 4 or None. Got {type(loaded_value)}. Using None.", file=sys.stderr)
-                            self.awareness[key] = None
-                # If key not in loaded_awareness, the default from __init__ remains.
-            
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
+            for key, expected_type in default_awareness_template.items():
+                if key in loaded_awareness_data:
+                    value = loaded_awareness_data[key]
+                    try:
+                        if expected_type == float:
+                            self.awareness[key] = float(value)
+                        elif expected_type == bool:
+                            self.awareness[key] = bool(value)
+                    except (ValueError, TypeError):
+                        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                            print(f"Warning (Persona load_state): Invalid type for awareness key '{key}'. Expected {expected_type}, got {type(value)}. Using default from __init__ ({self.awareness.get(key)}).", file=sys.stderr)
+                
+            loaded_coord = loaded_awareness_data.get("primary_concept_coord")
+            if loaded_coord is None:
+                self.awareness["primary_concept_coord"] = None
+            elif isinstance(loaded_coord, (list, tuple)) and len(loaded_coord) == 4:
+                try:
+                    self.awareness["primary_concept_coord"] = tuple(float(v) for v in loaded_coord)
+                except (ValueError, TypeError):
+                    if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                        print(f"Warning (Persona load_state): 'primary_concept_coord' in profile has non-numeric values: {loaded_coord}. Setting to None.", file=sys.stderr)
+                    self.awareness["primary_concept_coord"] = None 
+            else: 
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona load_state): 'primary_concept_coord' in profile is malformed: {loaded_coord}. Expected list/tuple of 4 or None. Setting to None.", file=sys.stderr)
+                self.awareness["primary_concept_coord"] = None 
+
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
                 print(f"Info (Persona load_state): Persona state loaded successfully from {self.profile_path}", file=sys.stderr)
                 print(f"Loaded Awareness: {self.awareness}", file=sys.stderr)
 
         except json.JSONDecodeError as e_json:
-            print(f"Error (Persona load_state): Malformed JSON in profile file '{self.profile_path}': {e_json}. Initializing default state.", file=sys.stderr)
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Error (Persona load_state): Malformed JSON in profile file '{self.profile_path}': {e_json}. Initializing default state.", file=sys.stderr)
             self._initialize_default_state_and_save()
         except Exception as e:
-            print(f"Error (Persona load_state): Unexpected error loading persona state from '{self.profile_path}': {e}. Initializing default state.", file=sys.stderr)
-            # Ensure traceback is imported for full error details
-            import traceback # Added import here
-            traceback.print_exc(file=sys.stderr) # Print stack trace for unexpected errors
+            if not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Error (Persona load_state): Unexpected error loading persona state from '{self.profile_path}': {e}. Initializing default state.", file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
             self._initialize_default_state_and_save()
 
     def get_intro(self) -> str:
         """
-        Generates an introductory statement for the persona, including name,
-        mode, key awareness metrics, and focus intensity if available.
+        Generates an introductory statement for the persona.
+        Includes name, mode, key awareness metrics, and focus intensity (T-value) if available.
+        The T-value is the raw 0-1 intensity from primary_concept_coord[3].
         """
         intro_parts = [f"Name: {self.name}", f"Mode: {self.mode}"]
         
-        # Add awareness metrics
         curiosity = self.awareness.get("curiosity", 0.0)
         coherence = self.awareness.get("coherence", 0.0)
         intro_parts.append(f"Curiosity: {curiosity:.2f}")
         intro_parts.append(f"Coherence: {coherence:.2f}")
 
-        # Add Focus Intensity (T-value) if primary_concept_coord is valid
         primary_coord = self.awareness.get("primary_concept_coord")
         if isinstance(primary_coord, (list, tuple)) and len(primary_coord) == 4:
             try:
-                # The T-value is the 4th element (index 3)
-                # This T-value is the *coordinate* value.
-                # The raw intensity (0-1) is more intuitive for display if available.
-                # Let's check if brain_awareness_metrics stored 'raw_t_intensity'
-                # For now, we'll assume primary_coord[3] is what we need to show,
-                # or that it's related to the raw intensity directly.
-                # If primary_coord[3] is already scaled to manifold range, it might be large.
-                # The prompt for brain.py's bootstrap_concept_from_llm stated:
-                # "t_coord_intensity: intensity (0 to 1) * (self.range / 2) - used as a coordinate"
-                # "raw_intensity = np.clip(float(llm_data["intensity"]), 0.0, 1.0)"
-                # So, primary_coord[3] is the scaled one. To get back to 0-1 raw intensity for display:
-                # raw_t_display = primary_coord[3] / (config.MANIFOLD_RANGE / 2.0) if config.MANIFOLD_RANGE else primary_coord[3]
-                # However, 'raw_t_intensity_at_storage' is also stored in the node by memory.py
-                # And brain.think() `awareness_metrics` should ideally pass the raw 0-1 `raw_t_intensity`.
-                # Let's assume `self.awareness` might have `raw_t_intensity` from an update,
-                # otherwise, we fall back to a message or don't display T if it's ambiguous from coord.
-                # For now, let's assume primary_coord[3] is the *coordinate value*.
-                # The requirement is "Focus Intensity (T): [value]". This implies the raw 0-1 intensity.
-                # If only coord[3] is available, and it's scaled, we'd need config.MANIFOLD_RANGE to de-normalize.
-                # Let's design get_intro to prefer a dedicated raw_t_intensity if available in self.awareness,
-                # which update_awareness should aim to populate.
-                # For now, if only primary_coord[3] (the coordinate) is there, we state it's the coordinate T-value.
-                # A better approach: update_awareness should store both coord and raw_t_intensity.
-                # Assuming update_awareness stores 'primary_concept_t_raw' if available from brain.
-                
-                t_value_display = None
-                if 'raw_t_intensity' in self.awareness and isinstance(self.awareness['raw_t_intensity'], (int, float)):
-                     t_value_display = self.awareness['raw_t_intensity']
-                elif primary_coord[3] is not None : # Fallback to using the coordinate if raw not available
-                    # This could be a large number if it's a coordinate.
-                    # The requirement is "Focus Intensity (T): [value]". This implies the raw 0-1 intensity.
-                    # If only coord[3] is available, and it's scaled, we'd need config.MANIFOLD_RANGE to de-normalize.
-                    # For now, just show the coordinate value if raw isn't there.
-                    # Or, better, state it's a coordinate.
-                    # The prompt says: "extract its T-value (intensity, index 3)"
-                    # Let's assume for now this means the raw 0-1 intensity that *should* be in awareness.
-                    # If it's not, we skip. update_awareness needs to ensure it's there.
-                    # For this implementation, let's assume 'primary_concept_coord' in awareness IS the raw 4-tuple (x,y,z, raw_t_intensity_0_to_1)
-                    # This simplifies get_intro, but update_awareness needs to ensure this format.
-                    # The brain.think() passes primary_concept_coord which *is* the scaled one.
-                    # This means update_awareness needs to de-normalize or brain needs to pass raw T separately.
-                    # RESOLUTION: For get_intro, I will assume primary_concept_coord[3] is the *raw 0-1 intensity*
-                    # as this makes the most sense for a "Focus Intensity (T): [value]" display.
-                    # This means `update_awareness` must ensure `self.awareness['primary_concept_coord'][3]` is the raw T.
-                    # The brain's `awareness_metrics` has `primary_concept_coord` (scaled) AND `raw_t_intensity`.
-                    # So `update_awareness` should ideally store `raw_t_intensity` separately or ensure `primary_concept_coord[3]` is the raw one.
-                    # For now, let's assume `update_awareness` stores `raw_t_intensity` in `primary_concept_coord[3]`.
-                    
-                    # Re-evaluating based on task: "awareness_metrics['primary_concept_coord'] is a 4-tuple of FLOATS (X,Y,Z,T_Intensity_RAW_0_to_1)."
-                    # This means primary_coord[3] IS the raw T intensity.
-                    t_value_display = float(primary_coord[3])
-
-                if t_value_display is not None:
-                    intro_parts.append(f"Focus Intensity (T): {t_value_display:.2f}")
-
+                raw_t_intensity = float(primary_coord[3])
+                intro_parts.append(f"Focus Intensity (T): {raw_t_intensity:.2f}")
             except (ValueError, TypeError, IndexError):
-                 # Silently ignore if coord[3] is not a valid number for T-intensity display
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona get_intro): Could not parse T-intensity from primary_concept_coord[3]: {primary_coord[3]}", file=sys.stderr)
                 pass 
                 
         return " | ".join(intro_parts)
@@ -331,158 +282,399 @@ class Persona:
     def update_awareness(self, brain_awareness_metrics: dict):
         """
         Updates the persona's awareness state based on metrics from brain.think().
-
-        Args:
-            brain_awareness_metrics: A dictionary containing awareness metrics
-                                     from the brain module. Expected keys include:
-                                     'curiosity', 'context_stability', 
-                                     'self_evolution_rate', 'coherence',
-                                     'active_llm_fallback', 'primary_concept_coord' (scaled),
-                                     and potentially 'raw_t_intensity' (0-1 scale).
+        Persona's self.awareness['primary_concept_coord'] will store:
+        (scaled_x, scaled_y, scaled_z, raw_t_intensity_0_to_1).
         """
         if not isinstance(brain_awareness_metrics, dict):
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
                 print(f"Warning (Persona update_awareness): Invalid brain_awareness_metrics type: {type(brain_awareness_metrics)}. No update.", file=sys.stderr)
             return
 
-        if config and getattr(config, 'VERBOSE_OUTPUT', False):
+        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
             print(f"Info (Persona update_awareness): Received brain metrics: {brain_awareness_metrics}", file=sys.stderr)
 
         changed = False
-        original_awareness_str = str(self.awareness) # For change detection
+        original_awareness_json = json.dumps(self.awareness, sort_keys=True)
 
-        # Iterate over expected keys in self.awareness and update from brain_metrics if valid
-        awareness_keys_to_process = {
+        metric_keys_to_process = {
             "curiosity": float, "context_stability": float, "self_evolution_rate": float,
             "coherence": float, "active_llm_fallback": bool
-            # primary_concept_coord is handled specially
         }
-
-        for key, expected_type in awareness_keys_to_process.items():
+        for key, expected_type in metric_keys_to_process.items():
             if key in brain_awareness_metrics:
                 new_value = brain_awareness_metrics[key]
+                current_value = self.awareness.get(key)
                 try:
                     if expected_type == float:
-                        new_value = float(new_value)
+                        typed_new_value = float(new_value)
                     elif expected_type == bool:
-                        new_value = bool(new_value)
-                    
-                    if self.awareness.get(key) != new_value:
-                        self.awareness[key] = new_value
+                        typed_new_value = bool(new_value)
+                    else: 
+                        typed_new_value = new_value 
+
+                    if current_value != typed_new_value:
+                        self.awareness[key] = typed_new_value
                         changed = True
                 except (ValueError, TypeError):
-                    if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                        print(f"Warning (Persona update_awareness): Invalid type for metric '{key}'. Expected {expected_type}, got {type(new_value)}. Not updated.", file=sys.stderr)
+                    if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                        print(f"Warning (Persona update_awareness): Invalid type for metric '{key}'. Expected {expected_type}, got {type(new_value)}. Retaining existing value: {current_value}", file=sys.stderr)
         
-        # Special handling for primary_concept_coord
-        # We want to store: (scaled_x, scaled_y, scaled_z, raw_t_intensity_0_to_1)
-        # Brain's awareness_metrics provides 'primary_concept_coord' (scaled) and 'raw_t_intensity' (0-1).
+        scaled_coord_from_brain = brain_awareness_metrics.get("primary_concept_coord")
+        raw_t_from_brain = brain_awareness_metrics.get("raw_t_intensity")
         
-        brain_primary_coord_scaled = brain_awareness_metrics.get("primary_concept_coord")
-        brain_raw_t_intensity = brain_awareness_metrics.get("raw_t_intensity") # This was added to brain.think() return for clarity
+        new_awareness_coord_to_set = self.awareness.get("primary_concept_coord") 
+        coord_update_attempted = False
 
-        new_coord_for_persona = None
-        valid_coord_received = False
-
-        if isinstance(brain_primary_coord_scaled, (list, tuple)) and len(brain_primary_coord_scaled) == 4:
-            if brain_raw_t_intensity is not None: # Prefer brain's explicit raw_t_intensity
+        if "primary_concept_coord" in brain_awareness_metrics: 
+            coord_update_attempted = True
+            if scaled_coord_from_brain is None:
+                if self.awareness.get("primary_concept_coord") is not None:
+                    new_awareness_coord_to_set = None
+                    changed = True
+            elif isinstance(scaled_coord_from_brain, (list, tuple)) and len(scaled_coord_from_brain) == 4:
                 try:
-                    # Construct (scaled_x, scaled_y, scaled_z, raw_t_0_1)
-                    new_coord_for_persona = (
-                        float(brain_primary_coord_scaled[0]),
-                        float(brain_primary_coord_scaled[1]),
-                        float(brain_primary_coord_scaled[2]),
-                        float(brain_raw_t_intensity) # Use the raw 0-1 intensity here
-                    )
-                    valid_coord_received = True
-                except (ValueError, TypeError, IndexError):
-                    if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                        print(f"Warning (Persona update_awareness): Invalid numeric types in brain's primary_concept_coord or raw_t_intensity. Coord: {brain_primary_coord_scaled}, RawT: {brain_raw_t_intensity}", file=sys.stderr)
-            else: # Fallback if brain_raw_t_intensity is not provided (older brain version?)
-                  # In this case, assume brain_primary_coord_scaled[3] IS the raw T (0-1), as per get_intro's assumption.
-                  # This path makes get_intro's assumption more critical for brain to fulfill if raw_t_intensity isn't separate.
-                try:
-                    new_coord_for_persona = tuple(float(v) for v in brain_primary_coord_scaled)
-                    # Ensure the T-value (coord[3]) is clipped to 0-1 if it's meant to be raw intensity here.
-                    new_coord_for_persona = (new_coord_for_persona[0], new_coord_for_persona[1], new_coord_for_persona[2], 
-                                             max(0.0, min(1.0, new_coord_for_persona[3])))
-                    valid_coord_received = True
-                    if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                        print(f"Warning (Persona update_awareness): 'raw_t_intensity' not found in brain metrics. Assuming primary_concept_coord[3] is raw T (0-1) and clipping.", file=sys.stderr)
-                except (ValueError, TypeError, IndexError):
-                    if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                        print(f"Warning (Persona update_awareness): Invalid numeric types in brain's primary_concept_coord when assuming direct use for raw T. Coord: {brain_primary_coord_scaled}", file=sys.stderr)
-        elif brain_primary_coord_scaled is None and 'primary_concept_coord' in brain_awareness_metrics: # Explicitly None
-            new_coord_for_persona = None # Set to None
-            valid_coord_received = True # Valid in the sense that None is an acceptable value
-        
-        if valid_coord_received:
-            if self.awareness.get("primary_concept_coord") != new_coord_for_persona:
-                self.awareness["primary_concept_coord"] = new_coord_for_persona
-                changed = True
-        elif 'primary_concept_coord' in brain_awareness_metrics: # If key was there but data was bad
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                print(f"Warning (Persona update_awareness): Received malformed 'primary_concept_coord': {brain_primary_coord_scaled}. Retaining existing or None.", file=sys.stderr)
+                    scaled_x = float(scaled_coord_from_brain[0])
+                    scaled_y = float(scaled_coord_from_brain[1])
+                    scaled_z = float(scaled_coord_from_brain[2])
+                    final_raw_t = None
 
+                    if raw_t_from_brain is not None:
+                        try:
+                            final_raw_t = float(raw_t_from_brain)
+                            if not (0.0 <= final_raw_t <= 1.0):
+                                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                                     print(f"Warning (Persona update_awareness): Received 'raw_t_intensity' {final_raw_t} outside 0-1 range. Clipping.", file=sys.stderr)
+                                final_raw_t = max(0.0, min(1.0, final_raw_t))
+                        except (ValueError, TypeError):
+                            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                                print(f"Warning (Persona update_awareness): Invalid type for 'raw_t_intensity': {raw_t_from_brain}. Will attempt fallback.", file=sys.stderr)
+                            final_raw_t = None 
 
+                    if final_raw_t is None: 
+                        if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                            print(f"Warning (Persona update_awareness): 'raw_t_intensity' missing or invalid in brain metrics. Falling back to scaled_coord[3] if it's in 0-1 range.", file=sys.stderr)
+                        
+                        fallback_t = float(scaled_coord_from_brain[3]) 
+                        if 0.0 <= fallback_t <= 1.0:
+                            final_raw_t = fallback_t
+                            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                                print(f"Info (Persona update_awareness): Using scaled_coord[3] ({fallback_t:.4f}) as raw T-intensity.", file=sys.stderr)
+                        else:
+                            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                                print(f"Warning (Persona update_awareness): Fallback scaled_coord[3] ({fallback_t:.4f}) is outside 0-1 range. Cannot determine raw T-intensity. Setting T to 0.0 in awareness coord.", file=sys.stderr)
+                            final_raw_t = 0.0 
+                    constructed_coord = (scaled_x, scaled_y, scaled_z, final_raw_t)
+                    if self.awareness.get("primary_concept_coord") != constructed_coord:
+                        new_awareness_coord_to_set = constructed_coord
+                        changed = True
+                
+                except (ValueError, TypeError, IndexError) as e:
+                    if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                        print(f"Warning (Persona update_awareness): Malformed 'primary_concept_coord' data: {scaled_coord_from_brain}. Error: {e}. Retaining existing.", file=sys.stderr)
+            
+            else: 
+                if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                    print(f"Warning (Persona update_awareness): Received 'primary_concept_coord' is not None and not a list/tuple of 4: {scaled_coord_from_brain}. Retaining existing.", file=sys.stderr)
+                
+            if coord_update_attempted: 
+                 if self.awareness.get("primary_concept_coord") != new_awareness_coord_to_set :
+                    self.awareness["primary_concept_coord"] = new_awareness_coord_to_set
         if changed:
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                print(f"Info (Persona update_awareness): Awareness changed. Old: {original_awareness_str}, New: {self.awareness}", file=sys.stderr)
+            new_awareness_json = json.dumps(self.awareness, sort_keys=True)
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Info (Persona update_awareness): Awareness changed.", file=sys.stderr)
+                print(f"  Old awareness subset: {original_awareness_json}", file=sys.stderr) 
+                print(f"  New awareness state: {new_awareness_json}", file=sys.stderr) 
             self.save_state()
         else:
-            if config and getattr(config, 'VERBOSE_OUTPUT', False):
-                print(f"Info (Persona update_awareness): No change in awareness metrics.", file=sys.stderr)
+            if config and getattr(config, 'VERBOSE_OUTPUT', False) and not (hasattr(sys, '_called_from_test') and sys._called_from_test):
+                print(f"Info (Persona update_awareness): No change in awareness metrics after processing: {brain_awareness_metrics}", file=sys.stderr)
 
-if __name__ == '__main__':
+# --- Self-Testing Block ---
+if __name__ == "__main__":
+    sys._called_from_test = True # Suppress normal operational print statements
+
+    # Ensure local Persona is used, not one from PYTHONPATH if different
+    current_module_persona = Persona 
+
     # --- Test Utilities ---
     class TempConfigOverride:
-        """Temporarily overrides attributes in the config module for testing persona.py."""
         def __init__(self, temp_configs_dict):
             self.temp_configs = temp_configs_dict
             self.original_values = {}
+            self.config_module = config # Use the 'config' resolved at module level
 
         def __enter__(self):
-            if not config:
-                print("CRITICAL_TEST_ERROR (persona.py): Config module not loaded in TempConfigOverride.", file=sys.stderr)
-                raise ImportError("Config module not loaded. Cannot override attributes for testing.")
-            
+            if not self.config_module:
+                # Create a dummy config object if it's None (e.g., standalone without ..config)
+                class DummyConfig: pass
+                self.config_module = DummyConfig()
+                # If 'config' was None globally, set it to this dummy for the duration of the test
+                # This is tricky because 'config' is a global in Persona's scope.
+                # For simplicity, we'll rely on the tests passing this dummy config module
+                # to Persona instances if needed, or Persona handling config=None.
+                # The tests will primarily set attributes on this temporary config_module.
+                global config
+                self.original_global_config = config
+                config = self.config_module
+                # print("TempConfigOverride: Created dummy config module.", file=sys.stderr)
+
+
             for key, value in self.temp_configs.items():
-                if hasattr(config, key):
-                    self.original_values[key] = getattr(config, key)
+                if hasattr(self.config_module, key):
+                    self.original_values[key] = getattr(self.config_module, key)
                 else:
-                    self.original_values[key] = None # Attribute didn't exist
-                setattr(config, key, value)
-            return self
+                    self.original_values[key] = "__ATTR_NOT_SET__" # Sentinel for attributes that didn't exist
+                setattr(self.config_module, key, value)
+            return self.config_module
 
         def __exit__(self, exc_type, exc_val, exc_tb):
-            if not config:
+            if not self.config_module:
                 return
-            
-            for key, original_value in self.original_values.items():
-                current_value_in_config = getattr(config, key, None)
-                if original_value is not None: # If there was an original value, restore it.
-                    if current_value_in_config != original_value:
-                        setattr(config, key, original_value)
-                elif key in self.temp_configs: # Attribute did not exist before but was set by this context manager.
-                    if hasattr(config, key): # Check if it's still there
-                        delattr(config, key)
-            
-            self.original_values.clear()
-            self.temp_configs.clear()
 
-    # --- Original __main__ preamble (or new test execution logic will start here) ---
-    print("core/persona.py loaded as main script.")
-    if config:
-        print(f"Config module successfully imported. PERSONA_NAME: {getattr(config, 'PERSONA_NAME', 'N/A')}")
-        print(f"Config PERSONA_PROFILE path: {getattr(config, 'PERSONA_PROFILE_PATH', 'N/A')}") # Corrected to PERSONA_PROFILE_PATH
-        # Ensure paths for testing if config is available
-        if hasattr(config, 'ensure_path') and hasattr(config, 'PERSONA_PROFILE_PATH'): # Corrected
+            for key, original_value in self.original_values.items():
+                if original_value == "__ATTR_NOT_SET__":
+                    if hasattr(self.config_module, key):
+                        delattr(self.config_module, key)
+                else:
+                    setattr(self.config_module, key, original_value)
+            
+            if hasattr(self, 'original_global_config'): # Restore original global config if it was changed
+                global config
+                config = self.original_global_config
+
+    TEST_PROFILE_FILENAME = "test_persona_profile.json"
+    # Place test profile in the same directory as this script for simplicity
+    TEST_PROFILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), TEST_PROFILE_FILENAME)
+
+    def delete_test_profile(profile_path=TEST_PROFILE_PATH):
+        if os.path.exists(profile_path):
             try:
-                # For tests, PERSONA_PROFILE will be overridden. 
-                # Ensure the default log path's directory from config exists if tests don't override it for system logs.
-                if hasattr(config, 'SYSTEM_LOG_PATH'):
-                    config.ensure_path(config.SYSTEM_LOG_PATH) 
-            except Exception as e_ensure:
-                print(f"Warning (persona.py __main__): Error ensuring default SYSTEM_LOG_PATH via config.ensure_path: {e_ensure}", file=sys.stderr)
+                os.remove(profile_path)
+            except OSError as e:
+                print(f"Warning: Could not delete test profile {profile_path}: {e}", file=sys.stderr)
+
+    test_results = {"passed": 0, "failed": 0, "details": []}
+
+    def _run_test(test_func, *args):
+        test_name = test_func.__name__
+        print(f"\n--- Running {test_name} ---")
+        try:
+            test_func(*args)
+            test_results["passed"] += 1
+            test_results["details"].append(f"[PASS] {test_name}")
+            print(f"[PASS] {test_name}")
+        except AssertionError as e:
+            test_results["failed"] += 1
+            error_info = traceback.format_exc()
+            test_results["details"].append(f"[FAIL] {test_name}: {e}\n{error_info}")
+            print(f"[FAIL] {test_name}: Assertion Error: {e}\n{error_info}", file=sys.stderr)
+        except Exception as e:
+            test_results["failed"] += 1
+            error_info = traceback.format_exc()
+            test_results["details"].append(f"[FAIL] {test_name}: Exception: {e}\n{error_info}")
+            print(f"[FAIL] {test_name}: Exception: {e}\n{error_info}", file=sys.stderr)
+        finally:
+            # Clean up profile after each test to ensure independence,
+            # unless a test specifically needs to persist it for a subsequent check by another test (not ideal).
+            # For these tests, cleanup is generally good.
+            delete_test_profile()
+
+
+    # --- Test Scenario Implementations ---
+
+    def test_initialization():
+        test_persona_name = "TestSophia"
+        with TempConfigOverride({"PERSONA_PROFILE_PATH": TEST_PROFILE_PATH, 
+                                 "VERBOSE_OUTPUT": False, 
+                                 "PERSONA_NAME": test_persona_name,
+                                 "ensure_path": lambda path: os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None}):
+            delete_test_profile()
+            persona = current_module_persona()
+
+            assert persona.name == test_persona_name, f"Name mismatch: expected {test_persona_name}, got {persona.name}"
+            assert persona.mode == "reflective", "Default mode mismatch"
+            assert persona.traits == ["CuriosityDriven", "EthicallyMinded", "ResonanceAware", "Developmental"], "Default traits mismatch"
+            
+            expected_awareness_keys = {"curiosity", "context_stability", "self_evolution_rate", "coherence", "active_llm_fallback", "primary_concept_coord"}
+            assert set(persona.awareness.keys()) == expected_awareness_keys, "Awareness keys mismatch"
+            assert isinstance(persona.awareness["curiosity"], float) and persona.awareness["curiosity"] == 0.5, "Default curiosity"
+            assert isinstance(persona.awareness["active_llm_fallback"], bool) and not persona.awareness["active_llm_fallback"], "Default llm_fallback"
+            assert persona.awareness["primary_concept_coord"] is None, "Default primary_concept_coord should be None"
+
+            intro = persona.get_intro()
+            assert "Focus Intensity (T):" not in intro, "Focus Intensity should not be in intro for new persona"
+            assert test_persona_name in intro, "Persona name not in intro"
+
+            assert os.path.exists(TEST_PROFILE_PATH), "Persona profile file was not created"
+            with open(TEST_PROFILE_PATH, 'r') as f:
+                saved_state = json.load(f)
+            assert saved_state["name"] == test_persona_name
+            assert saved_state["awareness"]["primary_concept_coord"] is None
+
+    def test_update_awareness():
+        with TempConfigOverride({"PERSONA_PROFILE_PATH": TEST_PROFILE_PATH, 
+                                 "VERBOSE_OUTPUT": False, # Set to True for debugging this test
+                                 "ensure_path": lambda path: os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None}):
+            delete_test_profile()
+            persona = current_module_persona()
+
+            # Scenario 1: Valid Full Metrics
+            brain_metrics_valid = { 
+                "curiosity": 0.8, "coherence": 0.75, "active_llm_fallback": True, 
+                "primary_concept_coord": (1.0, 2.0, 3.0, 75.0), # Brain sends scaled T-coord
+                "raw_t_intensity": 0.75, 
+                "context_stability": 0.85, "self_evolution_rate": 0.05 
+            }
+            persona.update_awareness(brain_metrics_valid)
+            assert persona.awareness["primary_concept_coord"] == (1.0, 2.0, 3.0, 0.75), f"PCC S1: {persona.awareness['primary_concept_coord']}"
+            assert "Focus Intensity (T): 0.75" in persona.get_intro(), f"Intro S1: {persona.get_intro()}"
+            assert persona.awareness["curiosity"] == 0.8
+            assert persona.awareness["active_llm_fallback"] is True
+
+            # Scenario 2: Partial Metrics
+            persona.update_awareness({"curiosity": 0.9, "self_evolution_rate": 0.1})
+            assert persona.awareness["curiosity"] == 0.9, "Curiosity S2"
+            assert persona.awareness["self_evolution_rate"] == 0.1, "SER S2"
+            assert persona.awareness["primary_concept_coord"] == (1.0, 2.0, 3.0, 0.75), "PCC S2 (should remain from S1)"
+
+            # Scenario 3: Malformed primary_concept_coord from Brain
+            original_pcc = persona.awareness['primary_concept_coord']
+            persona.update_awareness({"primary_concept_coord": "not-a-tuple", "raw_t_intensity": "bad-type"})
+            assert persona.awareness['primary_concept_coord'] == original_pcc, "PCC S3 (should remain from S2)"
+
+            # Scenario 4: primary_concept_coord is None from Brain
+            persona.update_awareness({"primary_concept_coord": None, "raw_t_intensity": None})
+            assert persona.awareness['primary_concept_coord'] is None, "PCC S4 (should be None)"
+            assert "Focus Intensity (T):" not in persona.get_intro(), "Intro S4 (no T-intensity)"
+            
+            # Scenario 5: Missing raw_t_intensity, but scaled_coord[3] is valid 0-1 (heuristic fallback)
+            persona.update_awareness({
+                "primary_concept_coord": (4.0, 5.0, 6.0, 0.88), # scaled_coord[3] is 0.88
+                # "raw_t_intensity": missing
+            })
+            assert persona.awareness["primary_concept_coord"] == (4.0, 5.0, 6.0, 0.88), f"PCC S5: {persona.awareness['primary_concept_coord']}"
+            assert "Focus Intensity (T): 0.88" in persona.get_intro(), f"Intro S5: {persona.get_intro()}"
+
+            # Scenario 6: Missing raw_t_intensity, and scaled_coord[3] is NOT valid 0-1 (heuristic fallback fails, T defaults to 0.0)
+            persona.update_awareness({
+                "primary_concept_coord": (7.0, 8.0, 9.0, 88.0), # scaled_coord[3] is 88.0 (not 0-1)
+                 # "raw_t_intensity": missing
+            })
+            assert persona.awareness["primary_concept_coord"] == (7.0, 8.0, 9.0, 0.0), f"PCC S6: {persona.awareness['primary_concept_coord']}"
+            assert "Focus Intensity (T): 0.00" in persona.get_intro(), f"Intro S6: {persona.get_intro()}"
+
+
+    def test_save_load_cycle():
+        with TempConfigOverride({"PERSONA_PROFILE_PATH": TEST_PROFILE_PATH, 
+                                 "VERBOSE_OUTPUT": False,
+                                 "ensure_path": lambda path: os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None}):
+            delete_test_profile()
+            persona1 = current_module_persona()
+            
+            metrics_to_save = { 
+                "curiosity": 0.66, 
+                "primary_concept_coord": (10.0, 20.0, 30.0, 99.0), # Scaled T-coord from brain
+                "raw_t_intensity": 0.99 # Raw T from brain
+            }
+            persona1.update_awareness(metrics_to_save)
+            persona1_awareness = persona1.awareness.copy() # Shallow copy is fine for this flat dict
+            
+            # persona1.save_state() is called by update_awareness if changed.
+            # Create a new persona instance, which should load from the saved profile.
+            persona2 = current_module_persona()
+
+            assert persona2.awareness == persona1_awareness, f"Awareness mismatch after load: P1: {persona1_awareness}, P2: {persona2.awareness}"
+            assert persona2.awareness['primary_concept_coord'] == (10.0, 20.0, 30.0, 0.99), f"PCC mismatch after load: {persona2.awareness['primary_concept_coord']}"
+            assert "Focus Intensity (T): 0.99" in persona2.get_intro(), f"Intro mismatch after load: {persona2.get_intro()}"
+
+    def test_load_old_format_profile():
+        with TempConfigOverride({"PERSONA_PROFILE_PATH": TEST_PROFILE_PATH,
+                                 "VERBOSE_OUTPUT": False,
+                                 "ensure_path": lambda path: os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None}):
+            delete_test_profile()
+            # Manually write an old format profile (missing some awareness fields, esp. primary_concept_coord)
+            old_profile_data = {"name": "OldSophia", "mode": "archaic", "traits": ["Classic"], "awareness": {"curiosity": 0.1, "coherence": 0.2}}
+            with open(TEST_PROFILE_PATH, 'w') as f:
+                json.dump(old_profile_data, f)
+            
+            persona = current_module_persona()
+            
+            assert persona.name == "OldSophia", "Name from old profile"
+            assert persona.mode == "archaic", "Mode from old profile"
+            assert persona.traits == ["Classic"], "Traits from old profile"
+            assert persona.awareness['curiosity'] == 0.1, "Curiosity from old profile"
+            assert persona.awareness['coherence'] == 0.2, "Coherence from old profile"
+            # Fields not in old profile should have defaults
+            assert persona.awareness['primary_concept_coord'] is None, "PCC from old profile (should be None)"
+            assert persona.awareness['context_stability'] == 0.5, "Context stability default" # Assuming 0.5 is default
+            assert "Focus Intensity (T):" not in persona.get_intro(), "Intro from old profile"
+
+    def test_load_malformed_profile():
+        with TempConfigOverride({"PERSONA_PROFILE_PATH": TEST_PROFILE_PATH,
+                                 "VERBOSE_OUTPUT": False,
+                                 "ensure_path": lambda path: os.makedirs(os.path.dirname(path), exist_ok=True) if os.path.dirname(path) else None}):
+            default_persona_name = "Sophia_Alpha2_Default_Reset" # Name after _initialize_default_state_and_save
+            
+            # Scenario 1: Empty File
+            delete_test_profile()
+            with open(TEST_PROFILE_PATH, 'w') as f:
+                f.write("") # Create empty file
+            persona_empty = current_module_persona()
+            assert persona_empty.name == default_persona_name, f"Empty file: Name {persona_empty.name}"
+            assert persona_empty.awareness["primary_concept_coord"] is None, "Empty file: PCC"
+
+            # Scenario 2: Invalid JSON
+            delete_test_profile()
+            with open(TEST_PROFILE_PATH, 'w') as f:
+                f.write("{invalid_json: ")
+            persona_invalid_json = current_module_persona()
+            assert persona_invalid_json.name == default_persona_name, f"Invalid JSON: Name {persona_invalid_json.name}"
+            assert persona_invalid_json.awareness["primary_concept_coord"] is None, "Invalid JSON: PCC"
+
+            # Scenario 3: Malformed primary_concept_coord in File (e.g., wrong length)
+            delete_test_profile()
+            malformed_pcc_profile = {"name": "TestPCC", "awareness": {"primary_concept_coord": [1, 2, 3]}} # List of 3, not 4
+            with open(TEST_PROFILE_PATH, 'w') as f:
+                json.dump(malformed_pcc_profile, f)
+            persona_malformed_pcc = current_module_persona()
+            assert persona_malformed_pcc.name == "TestPCC", f"Malformed PCC file: Name {persona_malformed_pcc.name}"
+            assert persona_malformed_pcc.awareness["primary_concept_coord"] is None, f"Malformed PCC file: PCC should be None, got {persona_malformed_pcc.awareness['primary_concept_coord']}"
+
+            # Scenario 4: Malformed primary_concept_coord in File (e.g., non-numeric)
+            delete_test_profile()
+            malformed_pcc_profile_non_numeric = {"name": "TestPCC2", "awareness": {"primary_concept_coord": [1, 2, 3, "not-a-number"]}}
+            with open(TEST_PROFILE_PATH, 'w') as f:
+                json.dump(malformed_pcc_profile_non_numeric, f)
+            persona_malformed_pcc_nn = current_module_persona()
+            assert persona_malformed_pcc_nn.name == "TestPCC2"
+            assert persona_malformed_pcc_nn.awareness["primary_concept_coord"] is None, f"Malformed PCC (non-numeric) file: PCC should be None, got {persona_malformed_pcc_nn.awareness['primary_concept_coord']}"
+
+
+    # --- Test Runner ---
+    print("Starting Persona Class Self-Tests...")
+    
+    _run_test(test_initialization)
+    _run_test(test_update_awareness)
+    _run_test(test_save_load_cycle)
+    _run_test(test_load_old_format_profile)
+    _run_test(test_load_malformed_profile)
+
+    print("\n--- Test Summary ---")
+    for detail in test_results["details"]:
+        print(detail.splitlines()[0]) # Print only the main pass/fail line for summary
+    
+    print(f"\nTotal Passed: {test_results['passed']}")
+    print(f"Total Failed: {test_results['failed']}")
+
+    # Clean up one last time
+    delete_test_profile()
+    del sys._called_from_test # Clean up the helper attribute
+
+    if test_results["failed"] > 0:
+        print("\nSOME TESTS FAILED.")
+        sys.exit(1)
     else:
-        print("Config module failed to import. Persona module functionality will be limited.")
+        print("\nALL TESTS PASSED.")
+        sys.exit(0)
+```

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -7,6 +7,7 @@ of the Sophia_Alpha2_ResonantBuild project.
 *   [Configuration (`config/config.py`)](#configuration-configconfigpy)
 *   [Core Cognitive Engine (`core/brain.py`)](#core-cognitive-engine-corebrainpy)
 *   [Memory System (`core/memory.py`)](#memory-system-corememorypy)
+*   [Persona Management (`core/persona.py`)](#persona-management-corepersonapy)
 
 ---
 
@@ -102,4 +103,60 @@ Key settings for `core/memory.py` include:
 
 The module includes a comprehensive self-testing suite (`if __name__ == "__main__":`).
 
+---
+
+## Persona Management (`core/persona.py`)
+
+The `core/persona.py` module defines and manages Sophia_Alpha2's identity, traits, operational mode, and awareness state. This is crucial for maintaining a consistent and evolving persona throughout her interactions and cognitive processes.
+
+### Module Overview
+`persona.py` encapsulates Sophia's characteristics and her dynamic understanding of her own operational state. This state is influenced by metrics received from the cognitive core (`core/brain.py`) and is persisted to a profile file, allowing Sophia's persona to be consistent across sessions and to evolve over time.
+
+### `Persona` Class
+This is the central class in `core/persona.py`.
+
+*   **Purpose:** Manages all aspects of Sophia's identity, including her name, current operational mode, inherent traits, and a detailed dictionary of awareness metrics.
+*   **Key Attributes:**
+    *   `name` (str): The name of the persona, e.g., "Sophia_Alpha2_Default".
+    *   `mode` (str): The current operational mode, such as "reflective", "learning", or "active_problem_solving".
+    *   `traits` (list[str]): A list of strings defining core characteristics, e.g., `["CuriosityDriven", "EthicallyMinded"]`.
+    *   `awareness` (dict): A dictionary holding various metrics that represent Sophia's current state of awareness. This includes:
+        *   `curiosity` (float): Her current level of curiosity.
+        *   `coherence` (float): The coherence of her current cognitive state.
+        *   `context_stability` (float): Stability of the current context.
+        *   `self_evolution_rate` (float): Rate of her own developmental change.
+        *   `active_llm_fallback` (bool): Whether the system is currently relying on LLM fallbacks.
+        *   `primary_concept_coord` (tuple | None): A 4-tuple `(x, y, z, t_intensity_raw)` representing the manifold coordinates of the current primary concept of focus, along with its raw T-intensity (0-1). This T-value, or Focus Intensity, indicates the intensity of focus on this concept. It is `None` if no concept is primary.
+
+### Key Methods
+*   **`__init__()`**: Initializes the Persona instance. It sets up default attributes (name, mode, traits, awareness metrics) and then attempts to load an existing persona state from the profile file defined by `config.PERSONA_PROFILE_PATH`. If no profile is found, or if it's malformed, it initializes with defaults and saves a new profile.
+*   **`update_awareness(brain_awareness_metrics: dict)`**: Updates the `awareness` dictionary based on new metrics received from `core/brain.py` (typically after a `think()` cycle). This method handles the logic for integrating new values, including the `primary_concept_coord` and its associated raw T-intensity. Changes are automatically saved to the profile.
+*   **`get_intro()`**: Generates a string that provides a brief introduction to the persona, including her name, mode, and key awareness metrics like curiosity, coherence, and the current Focus Intensity (T-value) if a primary concept is active.
+*   **`save_state()` / `load_state()`**: These methods handle the persistence of the persona's state. `save_state()` writes the current attributes to the JSON profile file and is typically called automatically when changes occur (e.g., in `update_awareness` or after initialization if a new profile is created). `load_state()` reads from the profile file during initialization, gracefully handling missing or malformed files by applying defaults.
+
+### Persistent Data (`persona_profile.json`)
+The state of the `Persona` class is persisted in a JSON file.
+
+*   **Path:** The path to this file is defined in `config.py` via the `config.PERSONA_PROFILE_PATH` setting. An example could be `data/private/persona_profile_default.json` or a user-configured path like `data/personas/Sophia_Alpha2_Default.json`.
+*   **Structure:** The JSON file generally contains the following structure:
+    ```json
+    {
+      "name": "Sophia_Alpha2_Default",
+      "mode": "reflective",
+      "traits": ["CuriosityDriven", "EthicallyMinded", "ResonanceAware", "Developmental"],
+      "awareness": {
+        "curiosity": 0.5,
+        "context_stability": 0.5,
+        "self_evolution_rate": 0.0,
+        "coherence": 0.0,
+        "active_llm_fallback": false,
+        "primary_concept_coord": [0.123, -0.456, 0.789, 0.85]
+      },
+      "last_saved": "2023-10-27T10:30:00.123456Z"
+    }
+    ```
+    *   If `primary_concept_coord` is not active or defined, its value will be `null` in the JSON file.
+    *   The `primary_concept_coord` array stores the X, Y, Z coordinates (scaled values as used within the manifold) and the fourth element is the raw T-intensity (a float between 0.0 and 1.0) representing the focus level.
+
+The module includes a comprehensive self-testing suite (`if __name__ == "__main__":`) which also serves as an example of how to interact with the `Persona` class.
 ```


### PR DESCRIPTION
This commit introduces the `core/persona.py` module, which is responsible for managing my identity, traits, operational mode, and evolving awareness state.

Key features of the `Persona` class include:
- Initialization with default attributes and loading from a persistent JSON profile (`persona_profile.json`).
- `update_awareness()`: Updates awareness metrics based on input from `core/brain.py`, including handling of `primary_concept_coord` (X,Y,Z scaled coordinates and raw T-intensity 0-1) and other metrics like curiosity and coherence.
- `get_intro()`: Generates an introductory statement that includes my name, mode, and key awareness metrics, including "Focus Intensity (T)" if available.
- `save_state()` and `load_state()`: Manage the persistence of my state, with robust error handling for missing or malformed profiles.
- A comprehensive self-testing suite (`if __name__ == "__main__":`) is included to ensure the module's functionality.

The `core/__init__.py` file has been updated to expose the `Persona` class. Documentation in `README.md` and `docs/documentation.md` has been updated to reflect the new module's functionality and its persisted data format.